### PR TITLE
add a simple webpack-based build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+dist
 .DS_Store
 node_modules
 npm-debug.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-modal-component",
   "version": "0.1.0",
   "description": "A simple modal component for Vue.js 2.x",
-  "main": "./main.js",
+  "main": "./dist/vue-modal-component.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cezardasilva/vue-modal-component.git"
@@ -21,5 +21,23 @@
   "homepage": "https://github.com/cezardasilva/vue-modal-component#readme",
   "peerDependencies": {
     "vue": "2.x.x"
+  },
+  "scripts": {
+    "dev": "cross-env NODE_ENV=development webpack --progress --watch",
+    "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
+    "prepare": "npm run build"
+  },
+  "files": [
+    "dist/vue-modal-component.js"
+  ],
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-env": "^1.6.1",
+    "cross-env": "^5.1.0",
+    "css-loader": "^0.28.7",
+    "vue-loader": "^13.3.0",
+    "vue-template-compiler": "^2.5.2",
+    "webpack": "^3.8.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,46 @@
+const webpack = require('webpack');
+const path = require('path');
+const PROD = process.env.NODE_ENV === 'production';
+
+module.exports = {
+    entry: path.resolve(__dirname + '/main.js'),
+
+    output: {
+        path: path.resolve(__dirname + '/dist/'),
+        filename: 'vue-modal-component.js',
+
+        libraryTarget: 'umd',
+        library: 'vue-modal-component',
+        umdNamedDefine: true,
+    },
+
+    module: {
+        loaders: [
+            {
+                test: /\.vue$/,
+                loader: 'vue-loader',
+                options: {
+                    loaders: {
+                        js: {
+                            loader: 'babel-loader',
+                            options: {
+                                presets: ['env'],
+                            },
+                        },
+                    },
+                },
+            },
+        ],
+    },
+
+    plugins: [
+        new webpack.optimize.UglifyJsPlugin({
+            minimize: PROD ? true : false,
+            sourceMap: PROD ? false : true,
+            mangle: PROD ? true: false,
+            compress: {
+                warnings: PROD ? false: true
+            },
+        }),
+    ],
+};


### PR DESCRIPTION
This adds a simple build so that when the component is used by others, they won't necessarily have to use vue-loader, it'll play nicer with uglify, etc. It's built using webpack.